### PR TITLE
fix missing remove interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { jsstoreEncryptMiddleware } from "./middleware";
-import { IInsertQuery, ISelectQuery, IColumnOption, IUpdateQuery, QUERY_OPTION, DATA_TYPE } from 'jsstore';
+import { IInsertQuery, ISelectQuery, IColumnOption, IUpdateQuery, IRemoveQuery, QUERY_OPTION, DATA_TYPE } from 'jsstore';
 
 declare module "jsstore" {
     interface IColumnOption {
@@ -13,6 +13,9 @@ declare module "jsstore" {
     }
     interface IUpdateQuery {
         encrypt?: boolean
+    }
+    interface IRemoveQuery {
+        decrypt?: boolean;
     }
 }
 export const encryptPlugin = {


### PR DESCRIPTION
When trying to do remove where on an encrypted column an error appears
saying that 'decrypt' is missing from the IRemoveQuery interface.